### PR TITLE
Add docs about R requirement

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,6 +19,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      # Install R; required for commands like `R CMD build` and `R CMD check`
       - uses: r-lib/actions/setup-r@v1
         with:
           use-public-rspm: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to parcutils
+
+This project uses standard R package tooling. To run local package checks or to build the package, you must have R installed and available on your `PATH`.
+
+The typical workflow is:
+
+```sh
+R CMD build .
+R CMD check parcutils_*tar.gz
+```
+
+Our continuous integration setup installs R using [r-lib/actions/setup-r](https://github.com/r-lib/actions/tree/master/setup-r). Ensure you have a compatible R installation when running these commands locally to avoid check failures.

--- a/README.Rmd
+++ b/README.Rmd
@@ -453,4 +453,10 @@ parcutils::get_star_align_log_summary_plot(x = star_align_log_files,
                                 col_mapped_reads  = "blue") 
 ```
 
-## 
+##
+
+## Building and checking the package
+
+To run `R CMD build` or `R CMD check` you must have R installed and accessible in your `PATH`. These commands are used by our CI pipeline and should also be used when testing the package locally.
+
+

--- a/README.md
+++ b/README.md
@@ -701,4 +701,9 @@ parcutils::get_star_align_log_summary_plot(x = star_align_log_files,
 
 ![](man/figures/README-unnamed-chunk-25-1.png)<!-- -->
 
-## 
+##
+
+## Building and checking the package
+
+To run `R CMD build` or `R CMD check` you must have R installed and accessible in your `PATH`. These commands are used by our CI pipeline and should also be used when testing the package locally.
+


### PR DESCRIPTION
## Summary
- mention that R must be installed in CI workflow
- add CONTRIBUTING guidelines describing the need for R
- state R requirement in README

## Testing
- `R CMD build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c845715c8330aa233455b4358877